### PR TITLE
ショートカットタスクのうち未完了のものの配列をリターンするように修正

### DIFF
--- a/src/domain/hooks/taskViewModel.ts
+++ b/src/domain/hooks/taskViewModel.ts
@@ -53,11 +53,13 @@ const taskPoolState = selector<Map<TaskId, Task>>({
   },
 });
 
+// ショートカットタスクのうち未完了のものの配列をリターン
 const shortcutTaskArrayState = selector<TaskId[]>({
   key: "shortcutTaskArray",
-  get: ({ get }) => {
-    return get(taskResponseState).shortcutTaskArray;
-  },
+  get: ({ get }) =>
+    get(taskResponseState).shortcutTaskArray.filter(
+      (taskId) => !get(taskState(taskId)).done
+    ),
 });
 
 export const taskState = selectorFamily<Task, TaskId>({


### PR DESCRIPTION
完了済みのタスクはSideNaviに表示されないように修正

![Screenshot from 2022-07-24 20-16-14](https://user-images.githubusercontent.com/65691831/180644511-423dc15e-49dc-4675-8c8d-4fde0990607b.png)
![Screenshot from 2022-07-24 20-16-01](https://user-images.githubusercontent.com/65691831/180644513-b72addb4-de7c-4a2e-87fc-99a829489318.png)